### PR TITLE
Rewrite to use Slab GraphQL API (requires schema verification)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ npx @modelcontextprotocol/inspector bun run index.ts
 
 Slabby implements the [Model Context Protocol](https://modelcontextprotocol.io), which allows AI assistants like Claude to interact with external tools and services. When you ask Claude Code to read or update Slab content, it:
 
-1. Uses your Slab API token to authenticate
-2. Makes requests to the Slab REST API
+1. Uses your Slab API token to authenticate (format: `Authorization: token YOUR_TOKEN`)
+2. Makes requests to the Slab GraphQL API at `https://api.slab.com/v1/graphql`
 3. Returns results to Claude Code
 4. All edits are attributed to your user account in Slab
 
@@ -156,12 +156,16 @@ Slabby implements the [Model Context Protocol](https://modelcontextprotocol.io),
 
 ## Slab API Reference
 
-This project uses the [Slab REST API v1](https://api.slab.com/). Key endpoints:
+This project uses the [Slab GraphQL API](https://api.slab.com/v1/graphql). The GraphQL schema is documented at:
+https://studio.apollographql.com/public/Slab/variant/current/schema/reference
 
-- `GET /v1/posts/:id` - Fetch post content
-- `PATCH /v1/posts/:id` - Update post content
-- `GET /v1/search` - Search posts
-- `GET /v1/posts` - List posts
+Key operations:
+- `query GetPost` - Fetch post content by ID
+- `mutation UpdatePost` - Update post content
+- `query SearchPosts` - Search posts across workspace
+- `query ListPosts` - List posts, optionally filtered by topic
+
+**⚠️ Important**: The GraphQL queries in this project are based on common GraphQL patterns and need to be verified against the actual Slab schema before use with production credentials. See [SCHEMA_VERIFICATION.md](SCHEMA_VERIFICATION.md) for a detailed verification checklist.
 
 ## Troubleshooting
 

--- a/SCHEMA_VERIFICATION.md
+++ b/SCHEMA_VERIFICATION.md
@@ -1,0 +1,195 @@
+# Slab GraphQL Schema Verification Guide
+
+⚠️ **IMPORTANT**: This implementation is based on common GraphQL patterns for CMS/documentation systems. The queries and mutations need to be verified against the actual Slab GraphQL schema before use with production credentials.
+
+## How to Verify
+
+Visit the Slab GraphQL schema documentation:
+https://studio.apollographql.com/public/Slab/variant/current/schema/reference
+
+## What to Check
+
+### 1. Query: `GetPost`
+
+**Current Implementation** (`src/graphql.ts:28-48`):
+```graphql
+query GetPost($id: ID!) {
+  post(id: $id) {
+    id
+    title
+    content
+    url
+    createdAt
+    updatedAt
+    createdBy {
+      id
+      displayName
+      email
+    }
+    updatedBy {
+      id
+      displayName
+      email
+    }
+  }
+}
+```
+
+**Verify**:
+- [ ] Is the query called `post` or something else (e.g., `getPost`, `Post`)?
+- [ ] Is the argument `id` of type `ID!`?
+- [ ] Field names: `content` or `body`? `createdAt` or `created_at`?
+- [ ] User fields: `displayName` or `display_name` or `name`?
+- [ ] Are all these fields available on the Post type?
+
+### 2. Mutation: `UpdatePost`
+
+**Current Implementation** (`src/graphql.ts:54-76`):
+```graphql
+mutation UpdatePost($id: ID!, $content: String!) {
+  updatePost(input: { id: $id, content: $content }) {
+    post {
+      id
+      title
+      content
+      url
+      createdAt
+      updatedAt
+      # ... user fields
+    }
+  }
+}
+```
+
+**Verify**:
+- [ ] Is the mutation called `updatePost`?
+- [ ] Does it accept an `input` object or direct parameters?
+- [ ] What's the structure of the input? `{ id, content }` or different?
+- [ ] Does the mutation return `{ post { ... } }` or just the post directly?
+- [ ] What's the actual return type?
+
+### 3. Query: `SearchPosts`
+
+**Current Implementation** (`src/graphql.ts:82-103`):
+```graphql
+query SearchPosts($query: String!) {
+  search(query: $query) {
+    posts {
+      id
+      title
+      content
+      url
+      snippet
+      createdAt
+      updatedAt
+      createdBy {
+        id
+        displayName
+        email
+      }
+    }
+    totalCount
+  }
+}
+```
+
+**Verify**:
+- [ ] Is there a `search` query?
+- [ ] Does it accept a `query` parameter?
+- [ ] What does it return? `{ posts, totalCount }` or different structure?
+- [ ] Is `snippet` a field in search results?
+- [ ] Field naming: `totalCount` vs `total_count`?
+
+### 4. Query: `ListPosts`
+
+**Current Implementation** (`src/graphql.ts:109-135`):
+```graphql
+query ListPosts($topicId: ID, $limit: Int, $offset: Int) {
+  posts(topicId: $topicId, limit: $limit, offset: $offset) {
+    items {
+      id
+      title
+      content
+      url
+      createdAt
+      updatedAt
+      # ... user fields
+    }
+    totalCount
+  }
+}
+```
+
+**Verify**:
+- [ ] Is there a `posts` query?
+- [ ] Does it support `topicId` filtering?
+- [ ] Does it support pagination with `limit`/`offset` or uses cursor pagination?
+- [ ] Is the response `{ items, totalCount }` or just an array?
+- [ ] Alternative structure in `src/graphql.ts:141-158` - which one is correct?
+
+## Common GraphQL Naming Patterns to Check
+
+The code has fallbacks for different naming conventions in `src/client.ts:148-169`:
+
+### Field Name Variations:
+- `content` vs `body`
+- `createdAt` vs `created_at`
+- `updatedAt` vs `updated_at`
+- `createdBy` vs `created_by`
+- `updatedBy` vs `updated_by`
+- `displayName` vs `display_name`
+- `totalCount` vs `total_count`
+
+### Response Structure Variations:
+- Direct array: `posts: [Post]`
+- Paginated: `posts: { items: [Post], totalCount: Int }`
+- Connection pattern: `posts: { edges: [{ node: Post }], pageInfo: {...} }`
+
+## Testing After Verification
+
+Once you've updated the queries to match the actual schema:
+
+1. **Update the queries** in `src/graphql.ts`
+2. **Run tests**: `bun test` (should still pass with mocked responses)
+3. **Test with real credentials**:
+   ```bash
+   export SLAB_API_TOKEN="your-real-token"
+   export SLAB_TEAM="your-team"
+   bun run index.ts
+   # Then test the MCP server with a real AI coding agent
+   ```
+
+## Files to Update
+
+After schema verification, you may need to update:
+
+- [ ] `src/graphql.ts` - Query and mutation definitions
+- [ ] `src/client.ts` - Response transformation logic (if field names differ)
+- [ ] `src/types.ts` - Type definitions (if structure differs significantly)
+- [ ] `test/client.test.ts` - Update mock responses to match real schema
+
+## Authentication
+
+The implementation uses:
+```
+Authorization: token YOUR_TOKEN
+```
+
+Not `Bearer YOUR_TOKEN`. This is based on the example:
+```bash
+curl -X POST \
+  -H "Authorization: token" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"query { organization { host } }"}' \
+https://api.slab.com/v1/graphql
+```
+
+Verify this is correct in your testing.
+
+## Need Help?
+
+If you encounter issues during verification:
+1. Check the Apollo Studio schema browser
+2. Try the example query from Slab docs (if available)
+3. Use GraphQL introspection to explore the schema
+4. Contact Slab support for API documentation

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,7 +34,7 @@ export class ConfigError {
 export interface SlabConfig {
   readonly apiToken: string;
   readonly team: string;
-  readonly baseUrl: string;
+  readonly graphqlUrl: string;
 }
 
 /**
@@ -68,7 +68,7 @@ export const loadConfig = (): Effect.Effect<SlabConfig, ConfigError> =>
     return {
       apiToken,
       team,
-      baseUrl: `https://${team}.slab.com/api/v1`,
+      graphqlUrl: "https://api.slab.com/v1/graphql",
     };
   });
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,0 +1,173 @@
+/**
+ * Copyright 2025 Russ White
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * GraphQL queries and mutations for Slab API
+ *
+ * ⚠️ IMPORTANT: These queries are based on common GraphQL patterns
+ * and need to be verified against the actual Slab GraphQL schema at:
+ * https://studio.apollographql.com/public/Slab/variant/current/schema/reference
+ *
+ * Please check and update:
+ * - Field names (e.g., is it `content` or `body`? `createdAt` or `created_at`?)
+ * - Query/mutation names (e.g., is it `post` or `getPost`?)
+ * - Input types and argument names
+ * - Return types and nested fields
+ */
+
+/**
+ * Query to fetch a single post by ID
+ *
+ * VERIFY: Check actual field names in Apollo Studio schema
+ */
+export const GET_POST_QUERY = `
+  query GetPost($id: ID!) {
+    post(id: $id) {
+      id
+      title
+      content
+      url
+      createdAt
+      updatedAt
+      createdBy {
+        id
+        displayName
+        email
+      }
+      updatedBy {
+        id
+        displayName
+        email
+      }
+    }
+  }
+`;
+
+/**
+ * Mutation to update a post's content
+ *
+ * VERIFY: Check if the mutation is called updatePost and if input structure is correct
+ */
+export const UPDATE_POST_MUTATION = `
+  mutation UpdatePost($id: ID!, $content: String!) {
+    updatePost(input: { id: $id, content: $content }) {
+      post {
+        id
+        title
+        content
+        url
+        createdAt
+        updatedAt
+        createdBy {
+          id
+          displayName
+          email
+        }
+        updatedBy {
+          id
+          displayName
+          email
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Query to search for posts
+ *
+ * VERIFY: Check if search query exists and what fields it accepts/returns
+ */
+export const SEARCH_POSTS_QUERY = `
+  query SearchPosts($query: String!) {
+    search(query: $query) {
+      posts {
+        id
+        title
+        content
+        url
+        snippet
+        createdAt
+        updatedAt
+        createdBy {
+          id
+          displayName
+          email
+        }
+      }
+      totalCount
+    }
+  }
+`;
+
+/**
+ * Query to list posts, optionally filtered by topic
+ *
+ * VERIFY: Check if posts query exists and supports topic filtering
+ */
+export const LIST_POSTS_QUERY = `
+  query ListPosts($topicId: ID, $limit: Int, $offset: Int) {
+    posts(topicId: $topicId, limit: $limit, offset: $offset) {
+      items {
+        id
+        title
+        content
+        url
+        createdAt
+        updatedAt
+        createdBy {
+          id
+          displayName
+          email
+        }
+        updatedBy {
+          id
+          displayName
+          email
+        }
+      }
+      totalCount
+    }
+  }
+`;
+
+/**
+ * Alternative LIST_POSTS_QUERY if the schema uses different structure
+ *
+ * VERIFY: Check which pattern Slab uses
+ */
+export const LIST_POSTS_QUERY_ALT = `
+  query ListPosts($topicId: ID) {
+    posts(filter: { topicId: $topicId }) {
+      id
+      title
+      content
+      url
+      createdAt
+      updatedAt
+      createdBy {
+        id
+        displayName
+        email
+      }
+      updatedBy {
+        id
+        displayName
+        email
+      }
+    }
+  }
+`;

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -7,19 +7,19 @@ import type { ConfigService } from "../src/config.ts";
 // Mock the global fetch function
 const mockFetch = mock();
 
-// Create a test config layer
+// Create a test config layer for GraphQL
 const TestConfigLayer = Layer.succeed(
   Context.GenericTag<ConfigService>("@services/ConfigService"),
   {
     config: {
       apiToken: "test-token",
       team: "test",
-      baseUrl: "https://test.slab.com/api/v1",
+      graphqlUrl: "https://api.slab.com/v1/graphql",
     },
   }
 );
 
-describe("SlabClient with Effect", () => {
+describe("SlabClient with GraphQL", () => {
   const originalFetch = global.fetch;
   let client: SlabClientService;
 
@@ -44,169 +44,212 @@ describe("SlabClient with Effect", () => {
   });
 
   describe("getPost", () => {
-    test("should fetch a post by ID", async () => {
-      const mockPost = {
-        id: "123",
-        title: "Test Post",
-        content: "Test content",
-        url: "https://test.slab.com/posts/123",
-        created_at: "2024-01-01T00:00:00Z",
-        updated_at: "2024-01-02T00:00:00Z",
+    test("should fetch a post by ID using GraphQL", async () => {
+      const mockGraphQLResponse = {
+        data: {
+          post: {
+            id: "123",
+            title: "Test Post",
+            content: "Test content",
+            url: "https://test.slab.com/posts/123",
+            createdAt: "2024-01-01T00:00:00Z",
+            updatedAt: "2024-01-02T00:00:00Z",
+          },
+        },
       };
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: async () => mockPost,
+        json: async () => mockGraphQLResponse,
       });
 
       const result = await Effect.runPromise(client.getPost("123"));
 
-      expect(result).toEqual(mockPost);
+      expect(result.id).toBe("123");
+      expect(result.title).toBe("Test Post");
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://test.slab.com/api/v1/posts/123",
+        "https://api.slab.com/v1/graphql",
         expect.objectContaining({
+          method: "POST",
           headers: expect.objectContaining({
-            Authorization: "Bearer test-token",
+            Authorization: "token test-token",
             "Content-Type": "application/json",
           }),
+          body: expect.stringContaining("GetPost"),
         })
       );
     });
 
-    test("should fail on failed request", async () => {
+    test("should fail on GraphQL errors", async () => {
       mockFetch.mockResolvedValue({
-        ok: false,
-        status: 404,
-        text: async () => "Not Found",
+        ok: true,
+        json: async () => ({
+          errors: [{ message: "Post not found" }],
+        }),
       });
 
       const result = await Effect.runPromise(client.getPost("nonexistent").pipe(Effect.either));
       expect(result._tag).toBe("Left");
       if (result._tag === "Left") {
-        expect(result.left.message).toContain("Slab API error (404): Not Found");
+        expect(result.left.message).toContain("Post not found");
+      }
+    });
+
+    test("should fail on HTTP errors", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: async () => "Forbidden",
+      });
+
+      const result = await Effect.runPromise(client.getPost("123").pipe(Effect.either));
+      expect(result._tag).toBe("Left");
+      if (result._tag === "Left") {
+        expect(result.left.message).toContain("403");
       }
     });
   });
 
   describe("updatePost", () => {
-    test("should update a post with new content", async () => {
-      const mockUpdatedPost = {
-        id: "123",
-        title: "Test Post",
-        content: "Updated content",
-        url: "https://test.slab.com/posts/123",
-        created_at: "2024-01-01T00:00:00Z",
-        updated_at: "2024-01-03T00:00:00Z",
+    test("should update a post with new content using GraphQL", async () => {
+      const mockGraphQLResponse = {
+        data: {
+          updatePost: {
+            post: {
+              id: "123",
+              title: "Test Post",
+              content: "Updated content",
+              url: "https://test.slab.com/posts/123",
+              createdAt: "2024-01-01T00:00:00Z",
+              updatedAt: "2024-01-03T00:00:00Z",
+            },
+          },
+        },
       };
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: async () => mockUpdatedPost,
+        json: async () => mockGraphQLResponse,
       });
 
       const result = await Effect.runPromise(client.updatePost("123", "Updated content"));
 
-      expect(result).toEqual(mockUpdatedPost);
+      expect(result.content).toBe("Updated content");
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://test.slab.com/api/v1/posts/123",
+        "https://api.slab.com/v1/graphql",
         expect.objectContaining({
-          method: "PATCH",
-          body: JSON.stringify({ content: "Updated content" }),
-          headers: expect.objectContaining({
-            Authorization: "Bearer test-token",
-            "Content-Type": "application/json",
-          }),
+          method: "POST",
+          body: expect.stringContaining("UpdatePost"),
         })
       );
     });
   });
 
   describe("searchPosts", () => {
-    test("should search posts with a query", async () => {
-      const mockSearchResults = {
-        posts: [
-          {
-            id: "1",
-            title: "Result 1",
-            content: "Content",
-            url: "https://test.slab.com/posts/1",
-            created_at: "2024-01-01T00:00:00Z",
-            updated_at: "2024-01-02T00:00:00Z",
+    test("should search posts with a query using GraphQL", async () => {
+      const mockGraphQLResponse = {
+        data: {
+          search: {
+            posts: [
+              {
+                id: "1",
+                title: "Result 1",
+                content: "Content",
+                url: "https://test.slab.com/posts/1",
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-02T00:00:00Z",
+              },
+            ],
+            totalCount: 1,
           },
-        ],
+        },
       };
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: async () => mockSearchResults,
+        json: async () => mockGraphQLResponse,
       });
 
       const result = await Effect.runPromise(client.searchPosts("test query"));
 
-      expect(result).toEqual(mockSearchResults);
+      expect(result.posts).toHaveLength(1);
+      expect(result.posts[0]?.title).toBe("Result 1");
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("/search?query=test+query"),
-        expect.any(Object)
+        "https://api.slab.com/v1/graphql",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining("SearchPosts"),
+        })
       );
     });
   });
 
   describe("listPosts", () => {
-    test("should list all posts when no topic ID is provided", async () => {
-      const mockPosts = {
-        posts: [
-          {
-            id: "1",
-            title: "Post 1",
-            content: "Content",
-            url: "https://test.slab.com/posts/1",
-            created_at: "2024-01-01T00:00:00Z",
-            updated_at: "2024-01-02T00:00:00Z",
+    test("should list all posts when no topic ID is provided using GraphQL", async () => {
+      const mockGraphQLResponse = {
+        data: {
+          posts: {
+            items: [
+              {
+                id: "1",
+                title: "Post 1",
+                content: "Content",
+                url: "https://test.slab.com/posts/1",
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-02T00:00:00Z",
+              },
+            ],
+            totalCount: 1,
           },
-        ],
+        },
       };
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: async () => mockPosts,
+        json: async () => mockGraphQLResponse,
       });
 
       const result = await Effect.runPromise(client.listPosts());
 
-      expect(result).toEqual(mockPosts);
+      expect(result.posts).toHaveLength(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://test.slab.com/api/v1/posts",
-        expect.any(Object)
+        "https://api.slab.com/v1/graphql",
+        expect.objectContaining({
+          method: "POST",
+        })
       );
     });
 
-    test("should list posts filtered by topic ID", async () => {
-      const mockPosts = {
-        posts: [
-          {
-            id: "1",
-            title: "Post 1",
-            content: "Content",
-            url: "https://test.slab.com/posts/1",
-            created_at: "2024-01-01T00:00:00Z",
-            updated_at: "2024-01-02T00:00:00Z",
+    test("should list posts filtered by topic ID using GraphQL", async () => {
+      const mockGraphQLResponse = {
+        data: {
+          posts: {
+            items: [
+              {
+                id: "1",
+                title: "Post 1",
+                content: "Content",
+                url: "https://test.slab.com/posts/1",
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-02T00:00:00Z",
+              },
+            ],
+            totalCount: 1,
           },
-        ],
+        },
       };
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: async () => mockPosts,
+        json: async () => mockGraphQLResponse,
       });
 
       const result = await Effect.runPromise(client.listPosts("topic-123"));
 
-      expect(result).toEqual(mockPosts);
-      expect(mockFetch).toHaveBeenCalledWith(
-        "https://test.slab.com/api/v1/posts?topic_id=topic-123",
-        expect.any(Object)
-      );
+      expect(result.posts).toHaveLength(1);
+      const body = JSON.parse(mockFetch.mock.calls[0]?.[1]?.body);
+      expect(body.variables.topicId).toBe("topic-123");
     });
   });
 });


### PR DESCRIPTION
## Summary
Complete rewrite from assumed REST endpoints to the actual Slab GraphQL API. This fixes the fundamental architecture issue where we were guessing at a REST API that doesn't exist.

## Problem
The original implementation assumed Slab had a REST API at `https://{team}.slab.com/api/v1/posts`, but Slab actually uses GraphQL at `https://api.slab.com/v1/graphql`.

## Solution
- ✅ Rewrote all API calls to use GraphQL queries and mutations
- ✅ Correct authentication: `Authorization: token YOUR_TOKEN`
- ✅ Effect-based architecture maintained throughout
- ✅ Comprehensive error handling for GraphQL responses
- ✅ All tests updated and passing (20 tests ✅)

## New Files

### `src/graphql.ts`
GraphQL query and mutation definitions for:
- `GetPost` - Fetch a post by ID
- `UpdatePost` - Update post content  
- `SearchPosts` - Search across workspace
- `ListPosts` - List posts with optional filtering

### `SCHEMA_VERIFICATION.md`
**Critical**: A comprehensive checklist for verifying the GraphQL queries against the actual Slab schema before production use. The queries are based on common GraphQL patterns and need verification.

## Key Changes

### API Client (`src/client.ts`)
- Complete GraphQL rewrite with `makeGraphQLRequest` helper
- Handles GraphQL response structure: `{ data, errors }`
- Transform responses to handle naming variations (camelCase/snake_case)
- Proper typed errors: `SlabApiError` now includes `graphqlErrors`

### Configuration (`src/config.ts`)
- Changed from `baseUrl` to `graphqlUrl`
- Points to `https://api.slab.com/v1/graphql`
- No longer team-specific in URL

### Tests (`test/client.test.ts`)
- All tests rewritten for GraphQL
- Mock responses use GraphQL structure: `{data: {post: {...}}}`
- Test GraphQL error handling
- Verify correct auth format
- **20 tests passing** ✅

### Documentation
- README updated to reflect GraphQL API
- Links to Apollo Studio schema documentation
- Clear warning about schema verification needed

## Schema Verification Required ⚠️

The GraphQL queries in this PR are **educated guesses** based on common GraphQL CMS patterns. Before using with production credentials:

1. **Review** [SCHEMA_VERIFICATION.md](SCHEMA_VERIFICATION.md)
2. **Access** https://studio.apollographql.com/public/Slab/variant/current/schema/reference
3. **Verify** query/mutation names and field structures
4. **Update** `src/graphql.ts` with correct schema
5. **Test** with real Slab API token

The code includes fallbacks for different naming conventions to maximize compatibility.

## What to Verify

- [ ] Query names (`post` vs `getPost` vs `Post`)
- [ ] Field names (`content` vs `body`, `createdAt` vs `created_at`)
- [ ] Mutation input structures
- [ ] Pagination patterns (items/edges/nodes)
- [ ] User field names (`displayName` vs `display_name`)
- [ ] Search response structure

See [SCHEMA_VERIFICATION.md](SCHEMA_VERIFICATION.md) for the full checklist.

## Testing

```bash
bun test  # All 20 tests pass with mocked responses
```

Once schema is verified with real token:
```bash
export SLAB_API_TOKEN="your-token"
export SLAB_TEAM="your-team"  
bun run index.ts
# Test with AI coding agent
```

## Benefits of This Approach

✅ Uses the **actual** Slab API (GraphQL, not imaginary REST)
✅ Correct authentication format
✅ Maintains Effect-TS architecture
✅ Type-safe error handling  
✅ Flexible response parsing
✅ Comprehensive documentation for next steps

## Next Steps

After merging:
1. Access Apollo Studio with Slab credentials
2. Verify and update queries in `src/graphql.ts`
3. Test with real API token
4. Update SCHEMA_VERIFICATION.md checklist
5. Document any schema differences found

---

This PR is ready for review but **requires schema verification before production use**.