### PR TITLE
Add npm publishing support with Node.js compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
   "name": "@russwyte/slabby",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP server for Slab knowledge base integration with AI coding agents",
-  "module": "index.ts",
+  "main": "./dist/index.js",
   "type": "module",
   "bin": {
-    "slabby": "./index.ts"
+    "slabby": "dist/index.js"
   },
   "scripts": {
     "start": "bun run index.ts",
     "dev": "bun run --watch index.ts",
+    "build": "bun build index.ts --target=node --outdir=dist --format=esm && bun build src/index.ts --target=node --outdir=dist/src --format=esm && sed -i '1s|#!/usr/bin/env bun|#!/usr/bin/env node|' dist/index.js",
     "test": "bun test",
     "test:watch": "bun test --watch",
-    "prepublishOnly": "bun test"
+    "prepublishOnly": "bun test && bun run build"
   },
   "files": [
-    "src",
-    "index.ts",
+    "dist",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
## Summary

- Configure package for npm publishing with compiled JavaScript output
- Add build script to transpile TypeScript to Node.js-compatible JavaScript
- Update package.json to point to dist/ output instead of TypeScript sources
- Package now published at https://www.npmjs.com/package/@russwyte/slabby

## Changes

### Build Configuration
- Added `build` script using Bun bundler targeting Node.js runtime
- Configured prepublishOnly hook to run tests and build automatically
- Build process converts Bun shebang to Node.js shebang for broader compatibility

### Package Configuration  
- Changed `main` from `index.ts` to `./dist/index.js`
- Updated `bin.slabby` from `./index.ts` to `dist/index.js`
- Modified `files` array to include only `dist/` folder (not source files)
- Bumped version from 0.1.0 to 0.1.1

### Benefits
- Package can now be installed globally via `npm install -g @russwyte/slabby`
- Works with Node.js while maintaining Bun-first development workflow
- Automated build process ensures published package is always up-to-date

## Test plan
- [x] Build script successfully compiles TypeScript to JavaScript
- [x] Tests pass before publishing (prepublishOnly hook)
- [x] Package published successfully to npm registry
- [x] Global installation works: `npm install -g @russwyte/slabby`
- [x] Installed binary is executable and has correct shebang