### PR TITLE
fix: align organization posts query with SlimPost schema and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,15 +142,15 @@ npx @modelcontextprotocol/inspector bun run index.ts
 
 Slabby implements the [Model Context Protocol](https://modelcontextprotocol.io), which allows AI assistants like Claude to interact with external tools and services. When you ask Claude Code to read or update Slab content, it:
 
-1. Uses your Slab API token to authenticate (format: `Authorization: token YOUR_TOKEN`)
+1. Uses your Slab API token to authenticate (format: `Authorization: Bearer YOUR_TOKEN`)
 2. Makes requests to the Slab GraphQL API at `https://api.slab.com/v1/graphql`
-3. Returns results to Claude Code
-4. All edits are attributed to your user account in Slab
+3. Converts Quill Delta content to Markdown for readability
+4. Returns results to Claude Code
 
 ## Security
 
 - **API tokens are stored locally** - Never sent to Anthropic's servers
-- **Edits show as you** - All changes attributed to your Slab account
+- **Markdown output** - Quill Delta content automatically converted to Markdown
 - **Read-only by default** - Update operations require explicit permission
 - **Environment-based config** - Tokens stored in `.env` (gitignored)
 
@@ -161,11 +161,12 @@ https://studio.apollographql.com/public/Slab/variant/current/schema/reference
 
 Key operations:
 - `query GetPost` - Fetch post content by ID
-- `mutation UpdatePost` - Update post content
-- `query SearchPosts` - Search posts across workspace
-- `query ListPosts` - List posts, optionally filtered by topic
+- `mutation UpdatePostContent` - Update post content using Quill Delta format
+- `query SearchPosts` - Search posts across workspace (cursor-based pagination)
+- `query GetTopicPosts` - List posts in a specific topic
+- `query GetOrganizationPosts` - List all posts in the organization
 
-**⚠️ Important**: The GraphQL queries in this project are based on common GraphQL patterns and need to be verified against the actual Slab schema before use with production credentials. See [SCHEMA_VERIFICATION.md](SCHEMA_VERIFICATION.md) for a detailed verification checklist.
+See [SCHEMA_VERIFICATION.md](SCHEMA_VERIFICATION.md) for detailed schema documentation.
 
 ## Troubleshooting
 

--- a/SCHEMA_VERIFICATION.md
+++ b/SCHEMA_VERIFICATION.md
@@ -79,12 +79,12 @@ Slab uses **camelCase** for GraphQL (not snake_case):
   { insert: "\n\n" }
 ]
 
-// Plain text (what we expose to MCP clients)
-"Hello World\n\n"
+// Markdown (what we expose to MCP clients, converted via quill-delta-to-html + turndown)
+"**Hello** World"
 ```
 
 Our implementation:
-- **Reading**: Converts Delta to plain text automatically
+- **Reading**: Converts Delta to Markdown automatically (via `quill-delta-to-html` → `turndown`)
 - **Writing**: Converts plain text to Delta and creates replacement operation
 
 ### ✅ Pagination
@@ -119,9 +119,14 @@ Since `posts(ids: [ID!]!)` doesn't support topic filtering, we use:
 - **Input**: Plain text from MCP clients
 - **Processing**: Convert to Quill Delta format
 - **Storage**: Delta format in Slab
-- **Output**: Plain text to MCP clients
+- **Output**: Markdown to MCP clients (Delta → HTML → Markdown)
 
-### 3. Update Strategy
+### 3. Organization Posts (SlimPost)
+`organization.posts` returns `[SlimPost!]!` which has fewer fields than `Post`:
+- Available: `id`, `linkAccess`, `archivedAt`, `publishedAt`, `title`, `topics` (as `[SlimTopic!]!` with only `id`)
+- NOT available: `content`, `insertedAt`, `updatedAt`, `owner`, `version`
+
+### 4. Update Strategy
 To update post content:
 1. GET current post to get current content
 2. Calculate replacement delta (delete all, insert new)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@russwyte/slabby",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@russwyte/slabby",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russwyte/slabby",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MCP server for Slab knowledge base integration with AI coding agents",
   "main": "./dist/index.js",
   "type": "module",

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -180,12 +180,10 @@ export const GET_ORGANIZATION_POSTS_QUERY = `
       posts {
         id
         title
-        insertedAt
         publishedAt
         linkAccess
         topics {
           id
-          name
         }
       }
     }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -232,11 +232,9 @@ describe("SlabClient with GraphQL (Verified Schema)", () => {
               {
                 id: "1",
                 title: "Post 1",
-                content: [{ insert: "Content" }, { insert: "\n\n" }],
-                insertedAt: "2024-01-01T00:00:00Z",
                 publishedAt: "2024-01-01T00:00:00Z",
                 linkAccess: "INTERNAL",
-                topics: [{ id: "topic1", name: "General" }],
+                topics: [{ id: "topic1" }],
               },
             ],
           },


### PR DESCRIPTION
## Summary
- **Bug fix**: Remove `insertedAt` and topic `name` from `GET_ORGANIZATION_POSTS_QUERY` — `organization.posts` returns `[SlimPost!]!` which doesn't have `insertedAt`, and `SlimPost.topics` returns `[SlimTopic!]!` which only has `id` (no `name`)
- **README**: Correct auth header format (`Bearer`), fix mutation/query names (`UpdatePostContent`, `GetTopicPosts`, `GetOrganizationPosts`), remove outdated schema verification warning
- **SCHEMA_VERIFICATION.md**: Update plain text references to Markdown, document SlimPost/SlimTopic field limitations

Verified against the actual Slab GraphQL schema from Apollo Studio.

## Test plan
- [x] All 20 tests pass with updated mock data